### PR TITLE
Update Fair Food project: ship it and refresh stats

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -127,14 +127,13 @@ const projects = [
   },
   {
     title: "Fair Food Volunteer Portal",
-    description: "Built for Fair Food Aotearoa, an Auckland-based charity that has rescued over 4.7 million kilos of surplus food since 2011. The portal coordinates volunteers across three programmes — Pack Kai Boxes, Conscious Kitchen, and Inclusive Volunteering — with accessibility-first shift booking, bilingual English/te reo Māori content, and tooling tailored to a community of 1,400+ active volunteers.",
+    description: "Built for Fair Food Aotearoa, an Auckland-based charity that has rescued over 4.7 million kilos of surplus food since 2011. The portal coordinates volunteers across three programmes — Pack Kai Boxes, Conscious Kitchen, and Inclusive Volunteering — with accessibility-first shift booking, bilingual English/te reo Māori content, and tooling tailored to a community of 300+ active volunteers.",
     github: "https://github.com/fairfoodnz/fairfood-volunteer",
     image: '/screenshots/fairfood.png',
     demo: 'https://volunteer.fairfood.org.nz/',
-    wip: true,
     stats: [
       { label: 'Food Rescued Since 2011', value: '4.7M kg' },
-      { label: 'Active Volunteers', value: '1,400+' },
+      { label: 'Volunteer Shifts / Month', value: '60+' },
     ],
   },
   {


### PR DESCRIPTION
## What changed

- Removed the `wip: true` flag from the **Fair Food Volunteer Portal** entry in `src/pages/index.astro`, so it now displays as a completed project rather than a work in progress.
- Updated the volunteer figure to **300+ active volunteers** (description text).
- Replaced the second stat with **Volunteer Shifts / Month: 60+**.

## Why

The Fair Food portal is no longer WIP and the old stats were stale. The previous "1,400+ active volunteers" figure was out of date — the correct active volunteer count is 300+.

## Reviewer notes

The "60+ shifts / month" figure is conservative. It's derived from Fair Food's live [SignUpGenius schedule](https://www.signupgenius.com/go/10c0d4dabab29a7fdc61-fair), which posts roughly 66–72 shift slots in every full month (Jun–Nov 2026 averaged ~69; 478 slots over ~7 months). `60+` follows the "X+" floor convention used by the other stats on the page; bump to `70+` if you'd prefer it to reflect the average.

🤖 Generated with [Claude Code](https://claude.com/claude-code)