### PR TITLE
Fix Fair Food stats: replace charity metric with portal scale

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -132,8 +132,8 @@ const projects = [
     image: '/screenshots/fairfood.png',
     demo: 'https://volunteer.fairfood.org.nz/',
     stats: [
-      { label: 'Food Rescued Since 2011', value: '4.7M kg' },
-      { label: 'Volunteer Shifts / Month', value: '60+' },
+      { label: 'Users', value: '300+' },
+      { label: 'Shifts / Month', value: '60+' },
     ],
   },
   {


### PR DESCRIPTION
## What changed

In `src/pages/index.astro`, the Fair Food Volunteer Portal stats are now:

- **Users: 300+** (was "Food Rescued Since 2011: 4.7M kg")
- **Shifts / Month: 60+** (relabeled from "Volunteer Shifts / Month")

## Why

PR #73 was merged after only its first commit landed; the follow-up commits that replaced the charity food-rescue figure and relabeled the stats never reached `develop`. "Food Rescued Since 2011" is a charity-wide metric, not a measure of the portal that was built — both stats now describe the delivered system instead.

## Reviewer notes

The "60+ shifts / month" figure is conservative, derived from Fair Food's live [SignUpGenius schedule](https://www.signupgenius.com/go/10c0d4dabab29a7fdc61-fair), which posts ~66–72 shift slots in every full month (Jun–Nov 2026 averaged ~69). It follows the "X+" floor convention used by the other stats on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)