### PR TITLE
Add Google Play link to Everybody Eats project

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -12,13 +12,14 @@ interface Props {
   github?: string;
   demo?: string;
   appStore?: string;
+  playStore?: string;
   stats?: Stat[];
   index?: number;
   wip?: boolean;
 }
 
 import { Image } from 'astro:assets';
-const { title, description, image, images, github, demo, appStore, stats, index = 0, wip = false } = Astro.props;
+const { title, description, image, images, github, demo, appStore, playStore, stats, index = 0, wip = false } = Astro.props;
 const isReversed = index % 2 !== 0;
 const hasMultipleImages = images && images.length > 1;
 ---
@@ -122,6 +123,20 @@ const hasMultipleImages = images && images.length > 1;
               <path d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"></path>
             </svg>
             App Store
+          </a>
+        )}
+        {playStore && (
+          <a
+            href={playStore}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="card-button card-button-playstore"
+            aria-label={`Download ${title} on Google Play`}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 512 512" fill="currentColor">
+              <path d="M325.3 234.3 104.6 13l280.8 161.2-60.1 60.1zM47 0C34 6.8 25.3 19.2 25.3 35.3v441.3c0 16.1 8.7 28.5 21.7 35.3l256.6-256L47 0zm425.2 225.6-58.9-34.1-65.7 64.5 65.7 64.5 60.1-34.1c18-14.3 18-46.5-1.2-60.8zM104.6 499l280.8-161.2-60.1-60.1L104.6 499z"></path>
+            </svg>
+            Google Play
           </a>
         )}
       </div>
@@ -283,6 +298,18 @@ const hasMultipleImages = images && images.length > 1;
     box-shadow: 0 4px 16px rgba(0, 122, 255, 0.35);
   }
 
+  .card-button-playstore {
+    color: white;
+    background: linear-gradient(135deg, rgba(52, 168, 83, 0.85), rgba(15, 157, 88, 0.85));
+    border: 1px solid rgba(52, 168, 83, 0.3);
+  }
+
+  .card-button-playstore:hover {
+    background: linear-gradient(135deg, rgba(52, 168, 83, 1), rgba(15, 157, 88, 1));
+    transform: translateY(-1px);
+    box-shadow: 0 4px 16px rgba(52, 168, 83, 0.35);
+  }
+
   /* Light mode styles */
   :global(html.light) .project-card {
     background: linear-gradient(135deg, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0.55));
@@ -351,6 +378,10 @@ const hasMultipleImages = images && images.length > 1;
 
   :global(html.light) .card-button-appstore {
     background: linear-gradient(135deg, rgba(0, 122, 255, 0.9), rgba(0, 64, 221, 0.9));
+  }
+
+  :global(html.light) .card-button-playstore {
+    background: linear-gradient(135deg, rgba(52, 168, 83, 0.95), rgba(15, 157, 88, 0.95));
   }
 
   /* Image overlay light mode */

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -104,11 +104,12 @@ const skillCategories = [
 const projects = [
   {
     title: "Everybody Eats Volunteer Portal",
-    description: "Built for Everybody Eats, a charity rescuing surplus food to serve free restaurant-quality meals to communities across New Zealand. The portal coordinates volunteer shifts across multiple kitchen locations, tracks individual and team achievements, and uses a gamification system with badges and leaderboards to drive ongoing engagement and retention. Available on web and as a native iOS app.",
+    description: "Built for Everybody Eats, a charity rescuing surplus food to serve free restaurant-quality meals to communities across New Zealand. The portal coordinates volunteer shifts across multiple kitchen locations, tracks individual and team achievements, and uses a gamification system with badges and leaderboards to drive ongoing engagement and retention. Available on web and as native iOS and Android apps.",
     github: "https://github.com/everybody-eats-nz/volunteer-portal",
     image: '/screenshots/volunteer-portal.png',
     demo: 'https://volunteers.everybodyeats.nz',
     appStore: 'https://apps.apple.com/nz/app/everybody-eats-nz/id6760931588',
+    playStore: 'https://play.google.com/store/apps/details?id=com.everybodyeats.app',
     stats: [
       { label: 'Volunteers', value: '9,000+' },
       { label: 'Weekly Active Users', value: '1.2K' },
@@ -449,6 +450,7 @@ const certifications = [
             github={project.github}
             demo={project.demo}
             appStore={project.appStore}
+            playStore={project.playStore}
             stats={project.stats}
             wip={project.wip}
             index={index}


### PR DESCRIPTION
## Summary
- Adds a Google Play button to the Everybody Eats Volunteer Portal card on the projects section, linking to https://play.google.com/store/apps/details?id=com.everybodyeats.app
- Extends `ProjectCard.astro` with a new `playStore` prop, a green-gradient Play Store button with the Google Play glyph, and matching light-mode styling
- Updates the EE project description to mention both iOS and Android native apps

## Test plan
- [ ] Run the dev server and confirm the new "Google Play" button renders next to the App Store button on the EE project card
- [ ] Verify the button links to the correct Play Store URL and opens in a new tab
- [ ] Check appearance in both dark and light modes
- [ ] Confirm other project cards (which don't set `playStore`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)