### PR TITLE
Replace Fair Food shifts/month stat with Lighthouse score

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -132,7 +132,7 @@ const projects = [
     demo: 'https://volunteer.fairfood.org.nz/',
     stats: [
       { label: 'Volunteers', value: '400+' },
-      { label: 'Shifts / Month', value: '60+' },
+      { label: 'Lighthouse', value: '100' },
     ],
   },
 ];


### PR DESCRIPTION
## What changed

Replaced the Fair Food Volunteer Portal stat **"Shifts / Month: 60+"** with **"Lighthouse: 100"** on the homepage project card.

## Why

A perfect Lighthouse score is a stronger, more concrete signal of the portal's quality (performance, accessibility, best practices) than the monthly shift count.

## Notes

- Single-line change in `src/pages/index.astro`.
- The Volunteers "400+" stat is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)