### PR TITLE
Refresh project stats with latest PostHog and volunteer numbers

### DIFF
--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -82,8 +82,8 @@ export const projects = [
     playStore: "https://play.google.com/store/apps/details?id=com.everybodyeats.app",
     stack: ["Next.js", "React", "TypeScript", "Prisma", "Postgres", "Expo"],
     stats: [
-      { label: "Volunteers", value: "9K+" },
-      { label: "Monthly Active Users", value: "4.8K" },
+      { label: "Volunteers", value: "10K+" },
+      { label: "Monthly Active Users", value: "4.6K" },
     ],
   },
   {
@@ -117,8 +117,8 @@ export const projects = [
     demo: "https://volunteer.fairfood.org.nz/",
     stack: ["Next.js", "React", "Prisma", "Postgres", "Tailwind", "Playwright"],
     stats: [
-      { label: "Active Volunteers", value: "400+" },
-      { label: "Monthly Page Views", value: "9K+" },
+      { label: "Active Volunteers", value: "500+" },
+      { label: "Monthly Page Views", value: "9.7K" },
     ],
   },
   {


### PR DESCRIPTION
## What changed

Updated the project stats in `src/data/site.ts`:

- **Everybody Eats - Volunteer Portal**: Volunteers 9K+ -> 10K+, Monthly Active Users 4.8K -> 4.6K
- **Fair Food - Volunteer Portal**: Active Volunteers 400+ -> 500+, Monthly Page Views 9K+ -> 9.7K

## Why

Volunteer counts come from the charities' latest numbers (Fair Food is over 500, Everybody Eats is over 10k). Traffic figures were pulled fresh from PostHog web analytics (last 30 days):

- EE portal: 4,648 unique visitors (no native `$screen` events exist, so this is the full MAU picture)
- Fair Food portal: 9,759 page views
- EE website: 7,129 visitors / 22,469 page views - existing 7K+ / 22K+ values still hold, so left unchanged

## Notes for review

MAU was revised slightly *down* (4.8K -> 4.6K) to match current data rather than rounding up. Verified rendering locally - all four updated values display correctly on the projects panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)